### PR TITLE
Fix-base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:latest as build-env
+FROM rust:latest AS build-env
 WORKDIR /app
 COPY . /app
 RUN cargo build --release
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc
 COPY --from=build-env /app/target/release/rust-bot ./
 CMD ["/rust-bot"]

--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ Telegram bot triggered by rust word.
    
 4. Build and run application
 
-   ```$ cargo run```
+```shell
+ cargo run
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - TELOXIDE_TOKEN=token
       - CHAT_GPT_API_TOKEN=gpt-token
       - DATABASE_URL=postgresql://docker:password@localhost:5432/postgres
-      - REDIS_URL=redis://default:redispw@localhost:55001
+      - REDIS_URL=redis://default:redispw@localhost:6379
     depends_on:
       - postgres
       - redis

--- a/src/rust_mention_handler.rs
+++ b/src/rust_mention_handler.rs
@@ -26,7 +26,7 @@ pub async fn handle_rust_matched_mention(
 ) {
     let message_date = message.date.timestamp();
     let curr_native_date = NaiveDateTime::from_timestamp_opt(message_date, 0).unwrap();
-    let curr_date: DateTime<Utc> = DateTime::from_utc(curr_native_date, Utc);
+    let curr_date: DateTime<Utc> = Utc.from_utc_datetime(&curr_native_date);
     info!(
         "rust mention invocation: chat_id: {}, time: {}",
         message.chat.id, curr_date


### PR DESCRIPTION
Temprory uses the old tag of base image `gcr.io/distroless/cc@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc`.

Reason: distroless/cc migrate to debian12 with the new version of `libssl3` that missing libssl.so.3