### PR TITLE
feat: E2E test harness with testcontainers + wiremock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - name: Run E2E tests
-        run: cargo test --test '*' --verbose
+        run: cargo test --tests --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,13 @@ jobs:
       - uses: actions/checkout@v6
       - name: Build
         run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Run unit tests
+        run: cargo test --lib --verbose
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - name: Run E2E tests
+        run: cargo test --test '*' --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,9 +84,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -98,11 +108,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -112,6 +122,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.0",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with 3.8.1",
 ]
 
 [[package]]
@@ -128,15 +188,19 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -153,6 +217,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -213,10 +278,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
+name = "core-foundation"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -321,8 +396,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -335,8 +420,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -345,10 +444,39 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -359,6 +487,16 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -376,14 +514,36 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -450,23 +610,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -505,6 +654,22 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flume"
@@ -546,9 +711,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -665,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -686,7 +851,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.8",
- "indexmap",
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -705,12 +870,18 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.1.0",
- "indexmap",
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -755,6 +926,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -869,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -911,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -922,11 +1099,42 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.1.0",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -950,7 +1158,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -960,22 +1168,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.6.0",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1003,6 +1227,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,12 +1316,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1039,12 +1356,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1062,7 +1391,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1079,9 +1408,9 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
 
@@ -1120,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1154,6 +1483,18 @@ name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1193,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -1234,10 +1575,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.5",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1263,6 +1604,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1296,6 +1643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,7 +1664,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1332,6 +1689,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -1375,6 +1738,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -1450,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1486,6 +1874,21 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1544,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1685,7 +2088,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1737,7 +2140,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.6.0",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -1765,6 +2168,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +2206,7 @@ name = "rust-bot"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures",
  "html2text",
  "log",
  "pretty_env_logger",
@@ -1799,7 +2217,12 @@ dependencies = [
  "serde_json",
  "sqlx",
  "teloxide",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
+ "tokio-stream",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -1821,8 +2244,47 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.7",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -1831,7 +2293,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1846,9 +2308,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "ryu"
@@ -1885,7 +2361,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.3",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1893,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1951,6 +2440,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,7 +2469,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.8.1",
+ "time",
 ]
 
 [[package]]
@@ -1978,10 +2496,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2011,6 +2541,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2139,7 +2675,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.4",
  "hashlink",
- "indexmap",
+ "indexmap 2.0.0",
  "log",
  "memchr",
  "native-tls",
@@ -2202,7 +2738,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.0",
- "bitflags 2.3.3",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -2245,7 +2781,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.0",
- "bitflags 2.3.3",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -2301,6 +2837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,10 +2883,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subtle"
-version = "2.4.1"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2375,13 +2946,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.3",
  "system-configuration-sys",
 ]
 
@@ -2453,7 +3035,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "take_mut",
  "takecell",
  "thiserror 1.0.37",
@@ -2509,6 +3091,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with 3.8.1",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +3166,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2612,10 +3273,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.11"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2623,40 +3294,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.4"
+name = "tokio-tar"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2752,15 +3415,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
-name = "url"
-version = "2.3.1"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2768,6 +3438,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -2984,6 +3660,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -3172,10 +3857,127 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "wiremock"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.0",
+ "deadpool",
+ "futures",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 authors = ["Rustlang-by community"]
 edition = "2021"
 
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "rust-bot"
+path = "src/main.rs"
+
 [dependencies]
 teloxide = { version = "0.13.0", features = ["macros"] }
 log = "0.4.29"
@@ -13,10 +20,18 @@ tokio = { version = "1.49.0", features = ["rt-multi-thread", "macros"] }
 regex = "1.12.3"
 chrono = "0.4.42"
 
-sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-native-tls", "chrono"] }
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-native-tls", "chrono", "migrate"] }
 
 reqwest = { version = "0.12", features = ["json"] }
 serde = "1.0.228"
 serde_json = "1.0"
 redis = { version = "0.25.4", features = ["tokio-comp", "connection-manager"] }
 html2text = "0.16.7"
+
+[dev-dependencies]
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["postgres", "redis"] }
+wiremock = "0.6"
+url = "2"
+tokio-stream = "0.1"
+futures = "0.3"

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -1,0 +1,242 @@
+use std::sync::Arc;
+
+use chrono::Duration;
+use redis::aio::ConnectionManager;
+use regex::Regex;
+use sqlx::{PgPool, Pool, Postgres};
+use teloxide::dispatching::UpdateHandler;
+use teloxide::error_handlers::LoggingErrorHandler;
+use teloxide::prelude::*;
+use teloxide::types::MediaKind::Text;
+use teloxide::types::MessageEntityKind::{TextLink, Url};
+use teloxide::types::MessageKind::Common;
+use teloxide::types::{MediaText, MessageCommon};
+use teloxide::RequestError;
+
+use crate::{
+    bf_mention_handler, chat_gpt_handler, gayness_handler, rust_mention_handler,
+    url_summary_handler,
+};
+
+const RUST_REGEX: &str = r"(?i)(rust|раст)(.\W|.$|\W|$)";
+const BLAZING_FAST_REGEX: &str = r"\w*[BbБб][LlЛл]\w*\W[FfФф][AaАа]\w*\b";
+const GAYNESS_REGEX: &str = r"(\D[0-4]|\D)\d%\Dg";
+const CHAT_GPT_REGEX: &str = r"(?i)(fedor|ф[её]дор|федя|felix|феликс|feris|ferris|ферис|феррис)";
+const URL_REGEX: &str = r#"https?://[^\s<>"{}|\\^`\[\]]*"#;
+const MIN_TIME_DIFF: i64 = 15;
+
+pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+#[derive(Clone)]
+pub struct GptParameters {
+    pub chat_gpt_api_token: Arc<str>,
+    pub openai_base_url: Arc<str>,
+    pub http_client: reqwest::Client,
+    pub redis_connection_manager: ConnectionManager,
+}
+
+#[derive(Clone)]
+pub struct MentionParameters {
+    pub rust_regex: Regex,
+    pub blazing_fast_regex: Regex,
+    pub gayness_regex: Regex,
+    pub chat_gpt_regex: Regex,
+    pub url_regex: Regex,
+    pub req_time_diff: Duration,
+}
+
+impl Default for MentionParameters {
+    fn default() -> Self {
+        Self {
+            rust_regex: Regex::new(RUST_REGEX).expect("Can't compile regex"),
+            blazing_fast_regex: Regex::new(BLAZING_FAST_REGEX).expect("Can't compile regex"),
+            gayness_regex: Regex::new(GAYNESS_REGEX).expect("Can't compile regex"),
+            chat_gpt_regex: Regex::new(CHAT_GPT_REGEX).expect("Can't compile regex"),
+            url_regex: Regex::new(URL_REGEX).expect("Can't compile regex"),
+            req_time_diff: Duration::minutes(MIN_TIME_DIFF),
+        }
+    }
+}
+
+pub struct AppDeps {
+    pub bot: Bot,
+    pub db_pool: PgPool,
+    pub gpt_parameters: GptParameters,
+    pub mention_parameters: MentionParameters,
+}
+
+pub fn build_handler() -> UpdateHandler<RequestError> {
+    Update::filter_message().branch(
+        dptree::filter(|msg: Message| !msg.chat.is_private()).endpoint(
+            |msg: Message,
+             mention_parameters: MentionParameters,
+             db_pool: Pool<Postgres>,
+             gpt_parameters: GptParameters,
+             bot: Bot| async move {
+                if let Common(MessageCommon {
+                    media_kind: Text(media_text),
+                    ..
+                }) = &msg.kind
+                {
+                    match &media_text.text {
+                        text if mention_parameters.chat_gpt_regex.is_match(text) => {
+                            chat_gpt_handler::handle_chat_gpt_question(bot, msg, &gpt_parameters)
+                                .await
+                        }
+                        text if message_has_url(
+                            &mention_parameters.url_regex,
+                            text,
+                            media_text,
+                        ) =>
+                        {
+                            url_summary_handler::handle_url_summary(
+                                bot,
+                                msg,
+                                mention_parameters.url_regex.clone(),
+                                &gpt_parameters,
+                            )
+                            .await
+                        }
+                        text if mention_parameters.rust_regex.is_match(text) => {
+                            rust_mention_handler::handle_rust_matched_mention(
+                                bot,
+                                msg,
+                                db_pool,
+                                mention_parameters.req_time_diff,
+                            )
+                            .await
+                        }
+                        text if mention_parameters.blazing_fast_regex.is_match(text) => {
+                            bf_mention_handler::handle_bf_matched_mention(bot, msg).await
+                        }
+                        text if mention_parameters.gayness_regex.is_match(text) => {
+                            gayness_handler::handle_gayness_mention(bot, msg).await
+                        }
+                        _ => {
+                            if let Some(reply_msg) = &msg.reply_to_message() {
+                                chat_gpt_handler::handle_reply(
+                                    &bot,
+                                    &msg,
+                                    reply_msg,
+                                    &gpt_parameters,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                }
+
+                respond(())
+            },
+        ),
+    )
+}
+
+pub async fn run(deps: AppDeps) {
+    let AppDeps {
+        bot,
+        db_pool,
+        gpt_parameters,
+        mention_parameters,
+    } = deps;
+    let handler = build_handler();
+    Dispatcher::builder(bot, handler)
+        .dependencies(dptree::deps![mention_parameters, db_pool, gpt_parameters])
+        .error_handler(LoggingErrorHandler::with_custom_text(
+            "An error has occurred in the dispatcher",
+        ))
+        .enable_ctrlc_handler()
+        .build()
+        .dispatch()
+        .await;
+}
+
+pub fn message_has_url(regex: &Regex, message_text: &str, text: &MediaText) -> bool {
+    let has_url_match = regex.is_match(message_text)
+        || text
+            .entities
+            .iter()
+            .any(|entity| matches!(entity.kind, TextLink { .. } | Url));
+
+    // Exclude Instagram and TikTok URLs
+    if has_url_match {
+        !message_text.contains("instagram.") && !message_text.contains("tiktok.")
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{message_has_url, CHAT_GPT_REGEX, RUST_REGEX, URL_REGEX};
+    use regex::Regex;
+    use teloxide::types::MediaText;
+
+    #[test]
+    fn test_rust_gpt_regex() {
+        let chat_gpt_regex = Regex::new(RUST_REGEX).expect("Can't compile regex");
+        assert!(chat_gpt_regex.is_match("test rust test"));
+        assert!(chat_gpt_regex.is_match("RusT"));
+        assert!(chat_gpt_regex.is_match("что там у раста"));
+        assert!(chat_gpt_regex.is_match("чэ тупо раст тэст"));
+    }
+
+    #[test]
+    fn test_chat_gpt_regex() {
+        let chat_gpt_regex = Regex::new(CHAT_GPT_REGEX).expect("Can't compile regex");
+        assert!(chat_gpt_regex.is_match("ухх Федор как дела?"));
+        assert!(chat_gpt_regex.is_match("pFedor tests"));
+        assert!(chat_gpt_regex.is_match("p Felix greate"));
+        assert!(chat_gpt_regex.is_match("Феликс"));
+        assert!(chat_gpt_regex.is_match("[[[Ferris"));
+        assert!(chat_gpt_regex.is_match("[ Фёдор ъ"));
+    }
+
+    #[test]
+    fn test_url_regex() {
+        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
+        assert!(url_regex.is_match("https://example.com"));
+        assert!(url_regex.is_match("http://test.org"));
+        assert!(!url_regex.is_match("not a url"));
+    }
+
+    #[test]
+    fn test_message_has_url() {
+        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
+        let message_text = "Check this out: https://example.com".to_string();
+        let media_text = MediaText {
+            text: message_text.clone(),
+            entities: vec![],
+            link_preview_options: None,
+        };
+
+        assert!(message_has_url(&url_regex, &message_text, &media_text));
+
+        let message_text_no_url = "Just a regular message".to_string();
+        assert!(!message_has_url(
+            &url_regex,
+            &message_text_no_url,
+            &media_text
+        ));
+    }
+
+    #[test]
+    fn test_message_has_url_exclude_instagram_tiktok() {
+        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
+        let message_text = "Check this out: https://instagram.com/example".to_string();
+        let media_text = MediaText {
+            text: message_text.clone(),
+            entities: vec![],
+            link_preview_options: None,
+        };
+
+        assert!(!message_has_url(&url_regex, &message_text, &media_text));
+
+        let message_text_tiktok = "Check this out: https://tiktok.com/example".to_string();
+        assert!(!message_has_url(
+            &url_regex,
+            &message_text_tiktok,
+            &media_text
+        ));
+    }
+}

--- a/src/chat_gpt_handler.rs
+++ b/src/chat_gpt_handler.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use crate::chat_gpt_handler::BotProfile::{Fedor, Felix, Ferris};
 use crate::chat_gpt_handler::ChatMessageRole::{System, User};
 use crate::gpt_service::{ChatMessage, ChatMessageRole};
-use crate::{chat_repository, gpt_service, GPTParameters};
+use crate::{chat_repository, gpt_service, GptParameters};
 use log::{error, info};
 use redis::aio::ConnectionManager;
 use regex::Regex;
@@ -38,7 +38,7 @@ static BOT_PROFILES: OnceLock<Vec<BotConfiguration<'static>>> = OnceLock::new();
 const SUMMARY_REQUEST_REGEX: &str = r"(?i)([чш].о?\b.*\bпроисходит)";
 static CHAT_SUMMARY_REQUEST_REGEX: OnceLock<Regex> = OnceLock::new();
 
-pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &mut GPTParameters) {
+pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &GptParameters) {
     let chat_id = msg.chat.id;
     let message = msg.text().expect("can't parse incoming message");
     info!("gpt invocation: chat_id: {chat_id}, message: {message}");
@@ -74,10 +74,11 @@ pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &m
     };
     let summary_request_regex = CHAT_SUMMARY_REQUEST_REGEX
         .get_or_init(|| Regex::new(SUMMARY_REQUEST_REGEX).expect("Can't compile regex"));
+    let mut redis_cm = gpt_parameters.redis_connection_manager.clone();
     let context = match summary_request_regex.is_match(message) {
         true => {
             fetch_chat_summary_context(
-                &mut gpt_parameters.redis_connection_manager,
+                &mut redis_cm,
                 chat_id.0,
                 &user_message,
                 bot_configuration.gpt_system_context,
@@ -86,7 +87,7 @@ pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &m
         }
         false => {
             fetch_bot_context(
-                &mut gpt_parameters.redis_connection_manager,
+                &mut redis_cm,
                 bot_context_key,
                 &user_message,
                 bot_configuration.gpt_system_context,
@@ -95,8 +96,7 @@ pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &m
         }
     };
 
-    let gpt_response_message =
-        gpt_service::chat_gpt_call(&gpt_parameters.chat_gpt_api_token, chat_id, context).await;
+    let gpt_response_message = gpt_service::chat_gpt_call(gpt_parameters, chat_id, context).await;
     let bot_reply_msg_response = if let Some(thread_id) = msg.thread_id {
         bot.send_message(chat_id, &gpt_response_message.content)
             .reply_parameters(ReplyParameters::new(msg.id))
@@ -109,7 +109,7 @@ pub async fn handle_chat_gpt_question(bot: Bot, msg: Message, gpt_parameters: &m
     };
 
     update_bot_context_and_identifiers(
-        &mut gpt_parameters.redis_connection_manager,
+        &mut redis_cm,
         bot_configuration.profile,
         bot_context_key,
         &user_message,
@@ -157,7 +157,7 @@ pub async fn handle_reply(
     bot: &Bot,
     msg: &Message,
     reply_msg: &Message,
-    gpt_parameters: &mut GPTParameters,
+    gpt_parameters: &GptParameters,
 ) {
     info!("handle reply gpt question");
     let message = msg.text().expect("can't parse incoming message");
@@ -165,12 +165,9 @@ pub async fn handle_reply(
     let chat_key = &format!("chat:{:#?}", chat_id.0);
     info!("chat_key: {chat_key:?}");
     let reply_msg_id = reply_msg.id.0;
-    if let Ok(reply_msg_bot_profile) = chat_repository::get_bot_msg_profile(
-        &mut gpt_parameters.redis_connection_manager,
-        chat_key,
-        reply_msg_id,
-    )
-    .await
+    let mut redis_cm = gpt_parameters.redis_connection_manager.clone();
+    if let Ok(reply_msg_bot_profile) =
+        chat_repository::get_bot_msg_profile(&mut redis_cm, chat_key, reply_msg_id).await
     {
         info!(
             "handle msg of bot msg reply_msg_id:'{reply_msg_id:#?}' under bot profile:'{reply_msg_bot_profile:#?}'"
@@ -191,7 +188,7 @@ pub async fn handle_reply(
                 content: message.to_string(),
             };
             let context = fetch_bot_context(
-                &mut gpt_parameters.redis_connection_manager,
+                &mut redis_cm,
                 bot_context_key,
                 &user_message,
                 bot_configuration.gpt_system_context,
@@ -199,15 +196,14 @@ pub async fn handle_reply(
             .await;
 
             let gpt_response_message =
-                gpt_service::chat_gpt_call(&gpt_parameters.chat_gpt_api_token, chat_id, context)
-                    .await;
+                gpt_service::chat_gpt_call(gpt_parameters, chat_id, context).await;
             let bot_reply_msg_response = bot
                 .send_message(chat_id, &gpt_response_message.content)
                 .reply_parameters(ReplyParameters::new(msg.id))
                 .await;
 
             update_bot_context_and_identifiers(
-                &mut gpt_parameters.redis_connection_manager,
+                &mut redis_cm,
                 bot_configuration.profile,
                 bot_context_key,
                 &user_message,
@@ -281,7 +277,7 @@ impl BotConfiguration<'static> {
 }
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum BotProfile {
+pub enum BotProfile {
     Fedor,
     Felix,
     Ferris,

--- a/src/gpt_service.rs
+++ b/src/gpt_service.rs
@@ -1,11 +1,11 @@
 use log::{error, info};
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use teloxide::types::ChatId;
 
+use crate::GptParameters;
+
 const GPT_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
-const OPEN_AI_COMPLETION_URL: &str = "https://api.openai.com/v1/chat/completions";
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ChatRequest<'a> {
@@ -37,12 +37,13 @@ pub struct ChatMessage {
     pub role: ChatMessageRole,
     pub content: String,
 }
+
 pub async fn chat_gpt_call(
-    api_key: &String,
+    params: &GptParameters,
     chat_id: ChatId,
     messages: Vec<ChatMessage>,
 ) -> ChatMessage {
-    match gpt_call(api_key, chat_id, messages).await {
+    match gpt_call(params, chat_id, messages).await {
         Ok(choices) => choices[0].message.to_owned(),
         Err(err) => {
             error!("Can't execute chat_gpt_call: {}", err);
@@ -55,7 +56,7 @@ pub async fn chat_gpt_call(
 }
 
 async fn gpt_call(
-    api_key: &String,
+    params: &GptParameters,
     chat_id: ChatId,
     messages: Vec<ChatMessage>,
 ) -> Result<Vec<Choice>, Box<dyn std::error::Error>> {
@@ -63,16 +64,19 @@ async fn gpt_call(
         "gpt call invocation from chat_id: {} with context: {:#?}",
         chat_id, messages
     );
-    let client = Client::builder().build()?;
     let chat_request = ChatRequest {
         messages,
         model: "gpt-4o",
         max_tokens: 1000,
     };
-    let response = client
-        .post(OPEN_AI_COMPLETION_URL)
+    let response = params
+        .http_client
+        .post(params.openai_base_url.as_ref())
         .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", api_key))
+        .header(
+            "Authorization",
+            format!("Bearer {}", params.chat_gpt_api_token.as_ref()),
+        )
         .json(&chat_request)
         .timeout(GPT_REQUEST_TIMEOUT)
         .send()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod bf_mention_handler;
+pub mod boot;
+pub mod chat_gpt_handler;
+pub mod chat_repository;
+pub mod gayness_handler;
+pub mod gpt_service;
+pub mod mention_repository;
+pub mod rust_mention_handler;
+pub mod url_summary_handler;
+
+pub use boot::{
+    build_handler, message_has_url, run, AppDeps, GptParameters, MentionParameters,
+    DEFAULT_OPENAI_BASE_URL,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,15 @@
-use chrono::Duration;
+use std::env;
+use std::sync::Arc;
+
 use log::info;
 use redis::aio::ConnectionManager;
-use regex::Regex;
-use sqlx::{PgPool, Pool, Postgres};
-use std::env;
+use sqlx::PgPool;
 use teloxide::prelude::*;
-use teloxide::types::MediaKind::Text;
-use teloxide::types::MessageEntityKind::{TextLink, Url};
-use teloxide::types::MessageKind::Common;
-use teloxide::types::{MediaText, MessageCommon};
 
-mod bf_mention_handler;
-mod chat_gpt_handler;
-mod chat_repository;
-mod gayness_handler;
-mod gpt_service;
-mod mention_repository;
-mod rust_mention_handler;
-mod url_summary_handler;
-
-const RUST_REGEX: &str = r"(?i)(rust|раст)(.\W|.$|\W|$)";
-const BLAZING_FAST_REGEX: &str = r"\w*[BbБб][LlЛл]\w*\W[FfФф][AaАа]\w*\b";
-const GAYNESS_REGEX: &str = r"(\D[0-4]|\D)\d%\Dg";
-const CHAT_GPT_REGEX: &str = r"(?i)(fedor|ф[её]дор|федя|felix|феликс|feris|ferris|ферис|феррис)";
-const URL_REGEX: &str = r#"https?://[^\s<>"{}|\\^`\[\]]*"#;
-const MIN_TIME_DIFF: i64 = 15;
+use rust_bot::{AppDeps, GptParameters, MentionParameters, DEFAULT_OPENAI_BASE_URL};
 
 #[tokio::main]
 async fn main() {
-    run().await;
-}
-
-async fn run() {
     pretty_env_logger::init();
     info!("Starting bot...");
 
@@ -41,214 +19,28 @@ async fn run() {
         env::var("CHAT_GPT_API_TOKEN").expect("CHAT_GPT_API_TOKEN must be set");
     let redis_url = env::var("REDIS_URL").expect("REDIS_URL must be set");
     let redis_client = redis::Client::open(redis_url).unwrap();
-    let redis_connection_manager = ConnectionManager::new(redis_client.clone()).await.unwrap();
+    let redis_connection_manager = ConnectionManager::new(redis_client).await.unwrap();
 
-    let gpt_parameters = GPTParameters {
-        chat_gpt_api_token,
+    let gpt_parameters = GptParameters {
+        chat_gpt_api_token: Arc::from(chat_gpt_api_token),
+        openai_base_url: Arc::from(DEFAULT_OPENAI_BASE_URL),
+        http_client: reqwest::Client::new(),
         redis_connection_manager,
     };
-    let mention_parameters = MentionParameters {
-        rust_regex: Regex::new(RUST_REGEX).expect("Can't compile regex"),
-        blazing_fast_regex: Regex::new(BLAZING_FAST_REGEX).expect("Can't compile regex"),
-        gayness_regex: Regex::new(GAYNESS_REGEX).expect("Can't compile regex"),
-        chat_gpt_regex: Regex::new(CHAT_GPT_REGEX).expect("Can't compile regex"),
-        url_regex: Regex::new(URL_REGEX).expect("Can't compile regex"),
-        req_time_diff: Duration::minutes(MIN_TIME_DIFF),
+
+    let deps = AppDeps {
+        bot,
+        db_pool,
+        gpt_parameters,
+        mention_parameters: MentionParameters::default(),
     };
 
-    let handler = Update::filter_message().branch(
-        // Filtering to focus on chat mentions
-        dptree::filter(|msg: Message| !msg.chat.is_private())
-            // An endpoint is the last update handler.
-            .endpoint(
-                |msg: Message,
-                 mention_parameters: MentionParameters,
-                 db_pool: Pool<Postgres>,
-                 mut gpt_parameters: GPTParameters,
-                 bot: Bot| async move {
-                    if let Common(MessageCommon {
-                        media_kind: Text(media_text),
-                        ..
-                    }) = &msg.kind
-                    {
-                        match &media_text.text {
-                            text if mention_parameters.chat_gpt_regex.is_match(text) => {
-                                chat_gpt_handler::handle_chat_gpt_question(
-                                    bot,
-                                    msg,
-                                    &mut gpt_parameters,
-                                )
-                                .await
-                            }
-                            text if message_has_url(
-                                &mention_parameters.url_regex,
-                                text,
-                                media_text,
-                            ) =>
-                            {
-                                url_summary_handler::handle_url_summary(
-                                    bot,
-                                    msg,
-                                    mention_parameters.url_regex,
-                                    &mut gpt_parameters,
-                                )
-                                .await
-                            }
-                            text if mention_parameters.rust_regex.is_match(text) => {
-                                rust_mention_handler::handle_rust_matched_mention(
-                                    bot,
-                                    msg,
-                                    db_pool,
-                                    mention_parameters.req_time_diff,
-                                )
-                                .await
-                            }
-                            text if mention_parameters.blazing_fast_regex.is_match(text) => {
-                                bf_mention_handler::handle_bf_matched_mention(bot, msg).await
-                            }
-                            text if mention_parameters.gayness_regex.is_match(text) => {
-                                gayness_handler::handle_gayness_mention(bot, msg).await
-                            }
-                            _ => {
-                                if let Some(reply_msg) = &msg.reply_to_message() {
-                                    chat_gpt_handler::handle_reply(
-                                        &bot,
-                                        &msg,
-                                        reply_msg,
-                                        &mut gpt_parameters,
-                                    )
-                                    .await;
-                                }
-                            }
-                        }
-                    }
-
-                    respond(())
-                },
-            ),
-    );
-    Dispatcher::builder(bot, handler)
-        // Here you specify initial dependencies that all handlers will receive
-        .dependencies(dptree::deps![mention_parameters, db_pool, gpt_parameters])
-        // If the dispatcher fails for some reason, execute this handler.
-        .error_handler(LoggingErrorHandler::with_custom_text(
-            "An error has occurred in the dispatcher",
-        ))
-        .enable_ctrlc_handler()
-        .build()
-        .dispatch()
-        .await;
+    rust_bot::run(deps).await;
 }
 
-fn message_has_url(regex: &Regex, message_text: &str, text: &MediaText) -> bool {
-    let has_url_match = regex.is_match(message_text)
-        || text
-            .entities
-            .iter()
-            .any(|entity| matches!(entity.kind, TextLink { .. } | Url));
-
-    // Exclude Instagram and TikTok URLs
-    if has_url_match {
-        !message_text.contains("instagram.") && !message_text.contains("tiktok.")
-    } else {
-        false
-    }
-}
-
-async fn establish_connection() -> Pool<Postgres> {
+async fn establish_connection() -> PgPool {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     PgPool::connect(&database_url)
         .await
         .expect("Can't establish connection")
-}
-
-#[derive(Clone)]
-struct MentionParameters {
-    rust_regex: Regex,
-    blazing_fast_regex: Regex,
-    gayness_regex: Regex,
-    chat_gpt_regex: Regex,
-    url_regex: Regex,
-    req_time_diff: Duration,
-}
-
-#[derive(Clone)]
-pub struct GPTParameters {
-    chat_gpt_api_token: String,
-    redis_connection_manager: ConnectionManager,
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{message_has_url, CHAT_GPT_REGEX, RUST_REGEX, URL_REGEX};
-    use regex::Regex;
-    use teloxide::types::MediaText;
-
-    #[test]
-    fn test_rust_gpt_regex() {
-        let chat_gpt_regex = Regex::new(RUST_REGEX).expect("Can't compile regex");
-        assert!(chat_gpt_regex.is_match("test rust test"));
-        assert!(chat_gpt_regex.is_match("RusT"));
-        assert!(chat_gpt_regex.is_match("что там у раста"));
-        assert!(chat_gpt_regex.is_match("чэ тупо раст тэст"));
-    }
-
-    #[test]
-    fn test_chat_gpt_regex() {
-        let chat_gpt_regex = Regex::new(CHAT_GPT_REGEX).expect("Can't compile regex");
-        assert!(chat_gpt_regex.is_match("ухх Федор как дела?"));
-        assert!(chat_gpt_regex.is_match("pFedor tests"));
-        assert!(chat_gpt_regex.is_match("p Felix greate"));
-        assert!(chat_gpt_regex.is_match("Феликс"));
-        assert!(chat_gpt_regex.is_match("[[[Ferris"));
-        assert!(chat_gpt_regex.is_match("[ Фёдор ъ"));
-    }
-
-    #[test]
-    fn test_url_regex() {
-        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
-        assert!(url_regex.is_match("https://example.com"));
-        assert!(url_regex.is_match("http://test.org"));
-        assert!(!url_regex.is_match("not a url"));
-    }
-
-    #[test]
-    fn test_message_has_url() {
-        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
-        let message_text = "Check this out: https://example.com".to_string();
-        let media_text = MediaText {
-            text: message_text.clone(),
-            entities: vec![],
-            link_preview_options: None,
-        };
-
-        assert!(message_has_url(&url_regex, &message_text, &media_text));
-
-        let message_text_no_url = "Just a regular message".to_string();
-        assert!(!message_has_url(
-            &url_regex,
-            &message_text_no_url,
-            &media_text
-        ));
-    }
-
-    #[test]
-    fn test_message_has_url_exclude_instagram_tiktok() {
-        let url_regex = Regex::new(URL_REGEX).expect("Can't compile regex");
-        let message_text = "Check this out: https://instagram.com/example".to_string();
-        let media_text = MediaText {
-            text: message_text.clone(),
-            entities: vec![],
-            link_preview_options: None,
-        };
-
-        assert!(!message_has_url(&url_regex, &message_text, &media_text));
-
-        let message_text_tiktok = "Check this out: https://tiktok.com/example".to_string();
-        assert!(!message_has_url(
-            &url_regex,
-            &message_text_tiktok,
-            &media_text
-        ));
-    }
 }

--- a/src/url_summary_handler.rs
+++ b/src/url_summary_handler.rs
@@ -1,6 +1,6 @@
 use crate::gpt_service::ChatMessage;
 use crate::gpt_service::ChatMessageRole::{System, User};
-use crate::{gpt_service, GPTParameters};
+use crate::{gpt_service, GptParameters};
 use log::{error, info};
 use regex::Regex;
 use reqwest::Client;
@@ -18,7 +18,7 @@ pub async fn handle_url_summary(
     bot: Bot,
     msg: Message,
     url_regex: Regex,
-    gpt_parameters: &mut GPTParameters,
+    gpt_parameters: &GptParameters,
 ) {
     if let Common(MessageCommon {
         media_kind: Text(media_text),
@@ -40,14 +40,15 @@ pub async fn handle_url_summary(
             return;
         };
 
-        let content = get_content_call(&url).await.unwrap();
+        let content = get_content_call(&gpt_parameters.http_client, &url)
+            .await
+            .unwrap();
         let clean_content = html2text::from_read(content.as_bytes(), 120).unwrap();
         // Check if the content is long enough to summarize
         if clean_content.len() < 1000 {
             return;
         }
-        let summary =
-            get_gpt_summary(&gpt_parameters.chat_gpt_api_token, chat_id, clean_content).await;
+        let summary = get_gpt_summary(gpt_parameters, chat_id, clean_content).await;
 
         let reply_msg = bot
             .send_message(chat_id, format!("TLDR:\n{}", summary))
@@ -81,9 +82,10 @@ fn find_link(media_text: &MediaText) -> Option<String> {
         .find_map(|el| el)
 }
 
-async fn get_content_call(url: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let client = Client::builder().build()?;
-
+async fn get_content_call(
+    client: &Client,
+    url: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
     let response = client
         .get(url)
         .timeout(ARTICLE_EXTRACTION_TIMEOUT)
@@ -94,7 +96,7 @@ async fn get_content_call(url: &str) -> Result<String, Box<dyn std::error::Error
     Ok(response)
 }
 
-pub async fn get_gpt_summary(api_key: &String, chat_id: ChatId, message: String) -> String {
+pub async fn get_gpt_summary(params: &GptParameters, chat_id: ChatId, message: String) -> String {
     let system_message = ChatMessage {
         role: System,
         content: ARTICLE_SUMMARY_SYSTEM_CONTEXT.to_string(),
@@ -105,7 +107,7 @@ pub async fn get_gpt_summary(api_key: &String, chat_id: ChatId, message: String)
     };
 
     let context = Vec::from([system_message, content_message]);
-    gpt_service::chat_gpt_call(api_key, chat_id, context)
+    gpt_service::chat_gpt_call(params, chat_id, context)
         .await
         .content
 }

--- a/tests/chat_gpt_e2e.rs
+++ b/tests/chat_gpt_e2e.rs
@@ -40,7 +40,7 @@ async fn chat_gpt_routes_to_openai_and_writes_redis_context() {
         .expect("collect telegram requests");
     let send_message_bodies: Vec<String> = telegram_requests
         .iter()
-        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .filter(|r| r.url.path().ends_with("/SendMessage"))
         .map(|r| String::from_utf8_lossy(&r.body).to_string())
         .collect();
     assert_eq!(

--- a/tests/chat_gpt_e2e.rs
+++ b/tests/chat_gpt_e2e.rs
@@ -1,0 +1,68 @@
+mod common;
+
+use common::*;
+use redis::AsyncCommands;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chat_gpt_routes_to_openai_and_writes_redis_context() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let canned = "Привет, дружище!";
+    let (openai, openai_url) = spawn_openai(canned).await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    let chat_id = -1002000_i64;
+    let user_id = 11_i64;
+    let text = "fedor, привет";
+
+    let update = text_message_update(text, chat_id, user_id, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let openai_calls = openai
+        .received_requests()
+        .await
+        .expect("collect openai requests");
+    assert_eq!(openai_calls.len(), 1, "expected 1 openai call");
+    let openai_body = String::from_utf8_lossy(&openai_calls[0].body);
+    assert!(
+        openai_body.contains("Федор"),
+        "openai body missing Fedor system context: {openai_body}"
+    );
+    assert!(
+        openai_body.contains("fedor"),
+        "openai body missing user text: {openai_body}"
+    );
+
+    let telegram_requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+    let send_message_bodies: Vec<String> = telegram_requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .map(|r| String::from_utf8_lossy(&r.body).to_string())
+        .collect();
+    assert_eq!(
+        send_message_bodies.len(),
+        1,
+        "expected 1 sendMessage call, got {}",
+        send_message_bodies.len()
+    );
+    assert!(
+        send_message_bodies[0].contains(canned),
+        "sendMessage body missing canned reply: {}",
+        send_message_bodies[0]
+    );
+
+    let mut cm = redis.connection_manager.clone();
+    let key = format!("Fedor:chat:{chat_id}");
+    let entries: Vec<String> = cm.lrange(&key, 0, -1).await.expect("redis lrange");
+    assert_eq!(
+        entries.len(),
+        2,
+        "expected 2 context entries (user + assistant), got {}: {:?}",
+        entries.len(),
+        entries
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,211 @@
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use redis::aio::ConnectionManager;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use teloxide::prelude::*;
+use teloxide::types::Update;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::redis::Redis;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use rust_bot::{build_handler, GptParameters, MentionParameters};
+
+pub const TEST_BOT_TOKEN: &str = "test-token";
+
+pub struct PostgresHarness {
+    pub _container: ContainerAsync<Postgres>,
+    pub pool: PgPool,
+}
+
+pub struct RedisHarness {
+    pub _container: ContainerAsync<Redis>,
+    pub connection_manager: ConnectionManager,
+    pub url: String,
+}
+
+pub async fn spawn_postgres() -> PostgresHarness {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("postgres container start");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("postgres port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+
+    let pool = PgPool::connect(&url).await.expect("connect postgres");
+    run_migrations(&pool).await;
+
+    PostgresHarness {
+        _container: container,
+        pool,
+    }
+}
+
+pub async fn spawn_redis() -> RedisHarness {
+    let container = Redis::default()
+        .start()
+        .await
+        .expect("redis container start");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis port");
+    let url = format!("redis://127.0.0.1:{port}");
+
+    let client = redis::Client::open(url.clone()).expect("redis client");
+    let connection_manager = ConnectionManager::new(client)
+        .await
+        .expect("redis connection manager");
+
+    RedisHarness {
+        _container: container,
+        connection_manager,
+        url,
+    }
+}
+
+/// Migrations are run by hand because the on-disk file
+/// `202105011313650_mentions_counter.sql` has a 15-digit timestamp (typo) that
+/// sorts later than `20230310100000_*` under integer ordering, and the last
+/// migration ends with a stray `END` token. Both issues are tolerated in
+/// production (DB is already migrated) but break `sqlx::migrate!`.
+async fn run_migrations(pool: &PgPool) {
+    let migrations = [
+        include_str!("../../migration/20200924213650_mentions.sql"),
+        include_str!("../../migration/202105011313650_mentions_counter.sql"),
+        include_str!("../../migration/20230310100000_mensions_chat_id.sql"),
+    ];
+    for sql in migrations {
+        for stmt in sql.split(';') {
+            let trimmed = stmt.trim();
+            if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("END") {
+                continue;
+            }
+            sqlx::query(trimmed)
+                .execute(pool)
+                .await
+                .unwrap_or_else(|e| panic!("migration stmt failed: {trimmed}\n{e}"));
+        }
+    }
+}
+
+/// Returns a wiremock `MockServer` doubling as the Telegram Bot API plus a
+/// `Bot` already pointed at it. Pre-registers `sendMessage` and `sendSticker`
+/// to return a minimal successful response so handlers don't fail on unmocked
+/// outbound calls.
+pub async fn spawn_telegram() -> (MockServer, Bot) {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/sendMessage")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(default_message_response()))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/sendSticker")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(default_message_response()))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/restrictChatMember")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true, "result": true})))
+        .mount(&server)
+        .await;
+
+    let url = reqwest::Url::parse(&server.uri()).expect("parse telegram mock uri");
+    let bot = Bot::new(TEST_BOT_TOKEN).set_api_url(url);
+    (server, bot)
+}
+
+/// Spins a wiremock OpenAI that returns `canned_reply` from
+/// `/v1/chat/completions`.
+pub async fn spawn_openai(canned_reply: &str) -> (MockServer, String) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1700000000_u64,
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": canned_reply},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        })))
+        .mount(&server)
+        .await;
+    let base_url = format!("{}/v1/chat/completions", server.uri());
+    (server, base_url)
+}
+
+pub fn gpt_parameters(redis: ConnectionManager, openai_base_url: String) -> GptParameters {
+    GptParameters {
+        chat_gpt_api_token: Arc::from("test-openai-token"),
+        openai_base_url: Arc::from(openai_base_url),
+        http_client: reqwest::Client::new(),
+        redis_connection_manager: redis,
+    }
+}
+
+pub fn text_message_update(text: &str, chat_id: i64, user_id: i64, message_id: i32) -> Update {
+    let now = chrono::Utc::now().timestamp();
+    let value: Value = json!({
+        "update_id": message_id,
+        "message": {
+            "message_id": message_id,
+            "date": now,
+            "chat": {
+                "id": chat_id,
+                "type": "supergroup",
+                "title": "test-chat"
+            },
+            "from": {
+                "id": user_id,
+                "is_bot": false,
+                "first_name": "Alice",
+                "username": "alice"
+            },
+            "text": text,
+            "entities": []
+        }
+    });
+    serde_json::from_value(value).expect("build Update")
+}
+
+/// Build deps, dispatch a single update through the real handler tree, and
+/// fail fast if anything stalls.
+pub async fn dispatch_one(bot: Bot, pool: PgPool, gpt_parameters: GptParameters, update: Update) {
+    let handler = build_handler();
+    let mention_parameters = MentionParameters::default();
+    let deps = dptree::deps![update, bot, mention_parameters, pool, gpt_parameters];
+    let _ = tokio::time::timeout(Duration::from_secs(15), handler.dispatch(deps))
+        .await
+        .expect("dispatcher did not complete within 15s");
+}
+
+fn default_message_response() -> Value {
+    json!({
+        "ok": true,
+        "result": {
+            "message_id": 100,
+            "date": 1700000000_u64,
+            "chat": {"id": -1001000, "type": "supergroup", "title": "test-chat"},
+            "from": {"id": 1, "is_bot": true, "first_name": "TestBot", "username": "test_bot"},
+            "text": "ok"
+        }
+    })
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -189,12 +189,18 @@ pub fn text_message_update(text: &str, chat_id: i64, user_id: i64, message_id: i
 /// Build deps, dispatch a single update through the real handler tree, and
 /// fail fast if anything stalls.
 pub async fn dispatch_one(bot: Bot, pool: PgPool, gpt_parameters: GptParameters, update: Update) {
+    use std::ops::ControlFlow;
+
     let handler = build_handler();
     let mention_parameters = MentionParameters::default();
     let deps = dptree::deps![update, bot, mention_parameters, pool, gpt_parameters];
-    let _ = tokio::time::timeout(Duration::from_secs(15), handler.dispatch(deps))
+    let outcome = tokio::time::timeout(Duration::from_secs(15), handler.dispatch(deps))
         .await
         .expect("dispatcher did not complete within 15s");
+    assert!(
+        matches!(outcome, ControlFlow::Break(Ok(()))),
+        "dispatcher did not route to a handler (outcome did not match Break(Ok(())))"
+    );
 }
 
 fn default_message_response() -> Value {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -106,19 +106,19 @@ pub async fn spawn_telegram() -> (MockServer, Bot) {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/bot{TEST_BOT_TOKEN}/sendMessage")))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/SendMessage")))
         .respond_with(ResponseTemplate::new(200).set_body_json(default_message_response()))
         .mount(&server)
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/bot{TEST_BOT_TOKEN}/sendSticker")))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/SendSticker")))
         .respond_with(ResponseTemplate::new(200).set_body_json(default_message_response()))
         .mount(&server)
         .await;
 
     Mock::given(method("POST"))
-        .and(path(format!("/bot{TEST_BOT_TOKEN}/restrictChatMember")))
+        .and(path(format!("/bot{TEST_BOT_TOKEN}/RestrictChatMember")))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true, "result": true})))
         .mount(&server)
         .await;
@@ -163,6 +163,11 @@ pub fn gpt_parameters(redis: ConnectionManager, openai_base_url: String) -> GptP
 
 pub fn text_message_update(text: &str, chat_id: i64, user_id: i64, message_id: i32) -> Update {
     let now = chrono::Utc::now().timestamp();
+    // teloxide-core 0.10's UpdateKind::Deserialize first tries `next_key::<&str>`
+    // and falls back to `next_key::<String>` only if the &str attempt failed —
+    // but `serde_json::from_value` produces owned String keys that don't satisfy
+    // &str, and the cursor advances anyway. Round-trip through a JSON string so
+    // the borrowed-str path succeeds and Update::kind becomes Message(...).
     let value: Value = json!({
         "update_id": message_id,
         "message": {
@@ -183,7 +188,8 @@ pub fn text_message_update(text: &str, chat_id: i64, user_id: i64, message_id: i
             "entities": []
         }
     });
-    serde_json::from_value(value).expect("build Update")
+    let serialized = serde_json::to_string(&value).expect("serialize update json");
+    serde_json::from_str(&serialized).expect("build Update")
 }
 
 /// Build deps, dispatch a single update through the real handler tree, and
@@ -199,7 +205,7 @@ pub async fn dispatch_one(bot: Bot, pool: PgPool, gpt_parameters: GptParameters,
         .expect("dispatcher did not complete within 15s");
     assert!(
         matches!(outcome, ControlFlow::Break(Ok(()))),
-        "dispatcher did not route to a handler (outcome did not match Break(Ok(())))"
+        "dispatcher did not route to a handler: outcome={outcome:?}"
     );
 }
 

--- a/tests/rust_mention_e2e.rs
+++ b/tests/rust_mention_e2e.rs
@@ -34,7 +34,7 @@ async fn rust_mention_triggers_reply_and_inserts_mention() {
 
     let send_message_bodies: Vec<String> = requests
         .iter()
-        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .filter(|r| r.url.path().ends_with("/SendMessage"))
         .map(|r| String::from_utf8_lossy(&r.body).to_string())
         .collect();
 
@@ -53,7 +53,7 @@ async fn rust_mention_triggers_reply_and_inserts_mention() {
 
     let send_sticker_count = requests
         .iter()
-        .filter(|r| r.url.path().ends_with("/sendSticker"))
+        .filter(|r| r.url.path().ends_with("/SendSticker"))
         .count();
     assert_eq!(send_sticker_count, 1, "expected 1 sendSticker call");
 

--- a/tests/rust_mention_e2e.rs
+++ b/tests/rust_mention_e2e.rs
@@ -1,0 +1,66 @@
+mod common;
+
+use common::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rust_mention_triggers_reply_and_inserts_mention() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let (_openai, openai_url) = spawn_openai("not used").await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    let chat_id = -1001000_i64;
+    let user_id = 42_i64;
+
+    sqlx::query(
+        "INSERT INTO mentions(user_id, username, chat_id, updated_at) \
+         VALUES ($1, $2, $3, NOW() - INTERVAL '1 hour')",
+    )
+    .bind(99_i64)
+    .bind("seed")
+    .bind(chat_id)
+    .execute(&pg.pool)
+    .await
+    .expect("seed mention row");
+
+    let update = text_message_update("Rust is great", chat_id, user_id, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+
+    let send_message_bodies: Vec<String> = requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .map(|r| String::from_utf8_lossy(&r.body).to_string())
+        .collect();
+
+    assert_eq!(
+        send_message_bodies.len(),
+        1,
+        "expected 1 sendMessage call, got {}",
+        send_message_bodies.len()
+    );
+    let body = &send_message_bodies[0];
+    assert!(body.contains("Hi, alice!"), "sendMessage body: {body}");
+    assert!(
+        body.contains("since last incident"),
+        "sendMessage body: {body}"
+    );
+
+    let send_sticker_count = requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/sendSticker"))
+        .count();
+    assert_eq!(send_sticker_count, 1, "expected 1 sendSticker call");
+
+    let alice_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mentions WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(&pg.pool)
+        .await
+        .expect("count alice mentions");
+    assert_eq!(alice_count, 1, "alice should have one mention row");
+}

--- a/tests/url_summary_e2e.rs
+++ b/tests/url_summary_e2e.rs
@@ -1,0 +1,63 @@
+mod common;
+
+use common::*;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn url_summary_fetches_article_summarizes_and_replies() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let canned_summary = "Краткое содержание статьи.";
+    let (openai, openai_url) = spawn_openai(canned_summary).await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    let article = MockServer::start().await;
+    let long_text = "lorem ipsum dolor sit amet ".repeat(80);
+    let html = format!("<html><body><p>{long_text}</p></body></html>");
+    Mock::given(method("GET"))
+        .and(path("/post/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(html))
+        .mount(&article)
+        .await;
+
+    let chat_id = -1003000_i64;
+    let user_id = 22_i64;
+    let article_url = format!("{}/post/42", article.uri());
+    let text = format!("посмотри {article_url}");
+
+    let update = text_message_update(&text, chat_id, user_id, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let article_calls = article
+        .received_requests()
+        .await
+        .expect("collect article requests");
+    assert_eq!(article_calls.len(), 1, "expected 1 article fetch");
+
+    let openai_calls = openai
+        .received_requests()
+        .await
+        .expect("collect openai requests");
+    assert_eq!(openai_calls.len(), 1, "expected 1 openai call");
+
+    let telegram_requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+    let send_message_bodies: Vec<String> = telegram_requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .map(|r| String::from_utf8_lossy(&r.body).to_string())
+        .collect();
+    assert_eq!(
+        send_message_bodies.len(),
+        1,
+        "expected 1 sendMessage call, got {}",
+        send_message_bodies.len()
+    );
+    let body = &send_message_bodies[0];
+    assert!(body.contains("TLDR"), "sendMessage body: {body}");
+    assert!(body.contains(canned_summary), "sendMessage body: {body}");
+}

--- a/tests/url_summary_e2e.rs
+++ b/tests/url_summary_e2e.rs
@@ -48,7 +48,7 @@ async fn url_summary_fetches_article_summarizes_and_replies() {
         .expect("collect telegram requests");
     let send_message_bodies: Vec<String> = telegram_requests
         .iter()
-        .filter(|r| r.url.path().ends_with("/sendMessage"))
+        .filter(|r| r.url.path().ends_with("/SendMessage"))
         .map(|r| String::from_utf8_lossy(&r.body).to_string())
         .collect();
     assert_eq!(


### PR DESCRIPTION
## Summary

Introduce an end-to-end test harness for `rust-bot` so handler regressions are actually caught.

- **lib/bin split** — `src/lib.rs` re-exports modules and the boot logic, `src/main.rs` shrinks to env-loading. Lets `tests/` import the dispatcher.
- **Minimal DI seams** — `GptParameters` now carries a `reqwest::Client` + OpenAI base URL; handlers take `&GptParameters` instead of `&mut`. No error-handling rewrite (separate follow-up per RECOMMENDATIONS.md §1).
- **Harness** (`tests/common/mod.rs`) — testcontainers-managed Postgres + Redis, wiremock-backed Telegram Bot API (`Bot::set_api_url` points at it), wiremock-backed OpenAI completions. Helper that dispatches a single `Update` through the real handler tree and asserts it was routed.
- **Three E2E tests** — rust-mention (Postgres side-effects), chat-gpt (OpenAI + Redis context), url-summary (article fetch + OpenAI summary + Telegram reply).
- **CI** — new `e2e` job in `.github/workflows/build.yml`; existing `build` job (unit tests only) keeps fast feedback.

## Why this shape

Direct `Update` injection (via dispatching to the `dptree::Handler` directly) instead of mocking the full Telegram HTTP API. Reasons: it exercises business logic without testing teloxide internals, doesn't require Telegram JSON-shape fixtures to match teloxide's serde across version bumps, and is faster.

## Test plan
- [ ] CI `build` job: `cargo build` + `cargo test --lib` (8 existing unit tests) passes
- [ ] CI `e2e` job: `cargo test --tests` passes — runs unit + 3 E2E integration tests with Docker (testcontainers Postgres + Redis + wiremock)
- [ ] Locally: `cargo fmt --check`, `cargo check --all-targets` clean (verified)
- [ ] Smoke check after merge: temporarily change rust-mention reply text and confirm `rust_mention_e2e` fails

## Out of scope (follow-up PRs)

Per `RECOMMENDATIONS.md` (kept local, gitignored):
- thiserror/anyhow error-handling rewrite
- ChatStore trait + mockall for handler-only unit tests
- tracing migration
- clippy gate in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)