### PR TITLE
build(deps): bump testcontainers to 0.24 and testcontainers-modules to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +2790,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3115,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "23bb7577dca13ad86a78e8271ef5d322f37229ec83b8d98da6d996c588a1ddb1"
 dependencies = [
  "async-trait",
  "bollard",
@@ -3125,7 +3136,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.10.0",
  "futures",
  "log",
  "memchr",
@@ -3144,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+checksum = "eac95cde96549fc19c6bf19ef34cc42bd56e264c1cb97e700e21555be0ecf9e2"
 dependencies = [
  "testcontainers",
 ]
@@ -3716,6 +3727,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ redis = { version = "0.25.4", features = ["tokio-comp", "connection-manager"] }
 html2text = "0.17.1"
 
 [dev-dependencies]
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres", "redis"] }
+testcontainers = "0.24"
+testcontainers-modules = { version = "0.12", features = ["postgres", "redis"] }
 wiremock = "0.6"
 url = "2"
 tokio-stream = "0.1"


### PR DESCRIPTION
Combines the two dependabot bumps that cannot land independently:
- #585 (testcontainers 0.23.3 → 0.24.0)
- #590 (testcontainers-modules 0.11.6 → 0.12.1)

`testcontainers-modules 0.12` requires `testcontainers 0.24`, so bumping either alone pulled **two versions** of `testcontainers` into the dependency graph, breaking the e2e test build with unsatisfied `testcontainers::Image` trait bounds. Bumping both together resolves it.

No test source changes were needed — the `AsyncRunner`/`ContainerAsync`/`get_host_port_ipv4` API is unchanged across the bump. `cargo test --no-run` compiles clean.

Supersedes #585 and #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)