### PR TITLE
ci(dependabot): group testcontainers with testcontainers-modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    # testcontainers-modules pins a specific testcontainers version, so the two
+    # must be bumped together — otherwise each lone PR splits the testcontainers
+    # version in the dependency graph and fails to compile the e2e tests.
+    groups:
+      testcontainers:
+        patterns:
+          - "testcontainers"
+          - "testcontainers-modules"
 
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
`testcontainers-modules` depends on a specific `testcontainers` version, so the two crates must be bumped together. Without grouping, Dependabot opened them as separate PRs (#585, #590); each lone bump put **two versions of `testcontainers`** in the dependency graph and failed the e2e build with unsatisfied `testcontainers::Image` trait bounds (fixed manually in #597).

This adds a Dependabot `group` so future bumps of these two crates always arrive as one combined PR that compiles and passes CI on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)