### PR TITLE
ci: add fmt/clippy/audit gates + pin toolchain to 1.97.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# cargo-audit / rustsec advisory triage.
+# Both advisories below have NO fixed upgrade available and neither ships in
+# the deployed binary; revisit when upstream publishes a fix.
+[advisories]
+ignore = [
+    # rsa timing sidechannel (Marvin). Phantom Cargo.lock entry pulled by
+    # sqlx's unused mysql backend — not compiled into any target we build.
+    "RUSTSEC-2023-0071",
+    # tokio-tar PAX header smuggling. Dev-dependency only (testcontainers),
+    # never present in the production artifact.
+    "RUSTSEC-2025-0111",
+]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+      - name: Format check
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -28,3 +38,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run E2E tests
         run: cargo test --tests --verbose
+
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Security audit
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Advisories with no fix that don't ship in the deployed binary.
+          # Kept in sync with .cargo/audit.toml (see there for rationale).
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2025-0111

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,15 +659,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
@@ -853,6 +844,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -1393,15 +1395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,7 +1811,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "phf_shared",
 ]
 
@@ -1964,6 +1957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,7 +1989,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2024,15 +2023,6 @@ dependencies = [
  "tokio-retry",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2081,15 +2071,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2185,7 +2166,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3093,16 +3074,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
- "fastrand 1.8.0",
- "libc",
- "redox_syscall 0.2.16",
- "remove_dir_all",
- "winapi",
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3485,7 +3465,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# Keep in lockstep with the Rust version pinned in the Dockerfile so local,
+# CI, and production builds all use the same compiler.
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
**Iteration 1/8** of the RECOMMENDATIONS.md hardening plan (§3 tooling/CI).

Adds quality gates to the PR workflow so every later change is guarded for free:
- **lint** job — `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings`. Both already pass on `main` (0 diff / 0 warnings), so this is pure enforcement, no code churn.
- **audit** job — `rustsec/audit-check` for dependency CVEs.
- **`rust-toolchain.toml`** pinned to `1.97.0` (matches the Dockerfile) so local, CI, and prod share one compiler.

### Security-audit triage
`cargo audit` surfaced 3 vulnerabilities; all handled:
| Advisory | Crate | Action |
|----------|-------|--------|
| RUSTSEC-2023-0018 | `remove_dir_all 0.5.3` | **Fixed** — bumped transitive `tempfile` 3.3.0 → 3.27.0 (drops the crate) |
| RUSTSEC-2023-0071 | `rsa 0.9.10` | **Ignored** — no fix; phantom Cargo.lock entry from sqlx's unused mysql backend, not compiled into any target |
| RUSTSEC-2025-0111 | `tokio-tar 0.3.1` | **Ignored** — no fix; testcontainers **dev-dependency**, never in the deployed binary |

Ignores live in `.cargo/audit.toml` (for local `cargo audit`) and mirrored in the workflow's `ignore` input, each with rationale.

Verified locally: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test --lib` (8 pass), `cargo audit` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)