### PR TITLE
feat(error): AppError + anyhow foundation, clean startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "aquamarine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2202,7 @@ dependencies = [
 name = "rust-bot"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "futures",
  "html2text",
@@ -2210,6 +2217,7 @@ dependencies = [
  "teloxide",
  "testcontainers",
  "testcontainers-modules",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "url",
@@ -3082,7 +3090,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde = "1.0.228"
 serde_json = "1.0"
 redis = { version = "0.25.4", features = ["tokio-comp", "connection-manager"] }
 html2text = "0.17.1"
+thiserror = "2"
+anyhow = "1"
 
 [dev-dependencies]
 testcontainers = "0.24"

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -132,7 +132,7 @@ pub fn build_handler() -> UpdateHandler<RequestError> {
     )
 }
 
-pub async fn run(deps: AppDeps) {
+pub async fn run(deps: AppDeps) -> anyhow::Result<()> {
     let AppDeps {
         bot,
         db_pool,
@@ -149,6 +149,7 @@ pub async fn run(deps: AppDeps) {
         .build()
         .dispatch()
         .await;
+    Ok(())
 }
 
 pub fn message_has_url(regex: &Regex, message_text: &str, text: &MediaText) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+/// Domain error for rust-bot.
+///
+/// Low-level failures from the infrastructure the bot talks to (Redis,
+/// Postgres, the Telegram Bot API, outbound HTTP) are translated into these
+/// variants at the handler boundaries via `#[from]`, so handlers can propagate
+/// with `?` and the dispatcher can log a single, typed error.
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+
+    #[error("postgres error: {0}")]
+    Postgres(#[from] sqlx::Error),
+
+    #[error("telegram error: {0}")]
+    Telegram(#[from] teloxide::RequestError),
+
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("gpt error: {0}")]
+    Gpt(String),
+
+    #[error("bad input: {0}")]
+    BadInput(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bf_mention_handler;
 pub mod boot;
 pub mod chat_gpt_handler;
 pub mod chat_repository;
+pub mod error;
 pub mod gayness_handler;
 pub mod gpt_service;
 pub mod mention_repository;
@@ -12,3 +13,4 @@ pub use boot::{
     build_handler, message_has_url, run, AppDeps, GptParameters, MentionParameters,
     DEFAULT_OPENAI_BASE_URL,
 };
+pub use error::AppError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::sync::Arc;
 
+use anyhow::Context;
 use log::info;
 use redis::aio::ConnectionManager;
 use sqlx::PgPool;
@@ -9,17 +10,21 @@ use teloxide::prelude::*;
 use rust_bot::{AppDeps, GptParameters, MentionParameters, DEFAULT_OPENAI_BASE_URL};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     pretty_env_logger::init();
     info!("Starting bot...");
 
-    let bot = Bot::from_env();
-    let db_pool = establish_connection().await;
+    let telegram_token = env::var("TELOXIDE_TOKEN").context("TELOXIDE_TOKEN must be set")?;
+    let bot = Bot::new(telegram_token);
+    let db_pool = establish_connection().await?;
     let chat_gpt_api_token =
-        env::var("CHAT_GPT_API_TOKEN").expect("CHAT_GPT_API_TOKEN must be set");
-    let redis_url = env::var("REDIS_URL").expect("REDIS_URL must be set");
-    let redis_client = redis::Client::open(redis_url).unwrap();
-    let redis_connection_manager = ConnectionManager::new(redis_client).await.unwrap();
+        env::var("CHAT_GPT_API_TOKEN").context("CHAT_GPT_API_TOKEN must be set")?;
+    let redis_url = env::var("REDIS_URL").context("REDIS_URL must be set")?;
+    let redis_client =
+        redis::Client::open(redis_url).context("failed to open Redis client from REDIS_URL")?;
+    let redis_connection_manager = ConnectionManager::new(redis_client)
+        .await
+        .context("failed to connect to Redis")?;
 
     let gpt_parameters = GptParameters {
         chat_gpt_api_token: Arc::from(chat_gpt_api_token),
@@ -35,12 +40,12 @@ async fn main() {
         mention_parameters: MentionParameters::default(),
     };
 
-    rust_bot::run(deps).await;
+    rust_bot::run(deps).await
 }
 
-async fn establish_connection() -> PgPool {
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+async fn establish_connection() -> anyhow::Result<PgPool> {
+    let database_url = env::var("DATABASE_URL").context("DATABASE_URL must be set")?;
     PgPool::connect(&database_url)
         .await
-        .expect("Can't establish connection")
+        .context("failed to connect to Postgres")
 }


### PR DESCRIPTION
**Iteration 2/8** of the hardening plan (§1 error handling — foundation).

- New `src/error.rs`: a `thiserror`-based `AppError` enum (`Redis`/`Postgres`/`Telegram`/`Http`/`Gpt`/`BadInput`) with `#[from]` conversions, exported from the crate root. Handlers will adopt it in Iteration 4.
- Adds `thiserror` + `anyhow`.
- `main()` / `run()` → `anyhow::Result<()>`; `establish_connection()` → `anyhow::Result<PgPool>`. All startup fallible steps (Telegram token, Postgres/Redis connect, env reads) propagate with `?` + `.context(...)` instead of `unwrap`/`expect`.
- Replaces `Bot::from_env()` (panics on missing token) with an explicit `TELOXIDE_TOKEN` read so all boot config fails uniformly.

**Result:** booting with missing config now prints a contextual error and exits 1 — verified:
```
$ ./rust-bot   # no env vars
Error: TELOXIDE_TOKEN must be set
Caused by:
    environment variable not found
$ echo $?
1
```
No happy-path behavior change. `main.rs` now has zero `unwrap`/`expect`. Local gate green (fmt, clippy `-D warnings`, 8 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)