### PR TITLE
test: fill repository and handler-route coverage gaps

### DIFF
--- a/tests/chat_repository_test.rs
+++ b/tests/chat_repository_test.rs
@@ -1,0 +1,56 @@
+//! Pure (no-container) coverage for the Redis serde impls in `chat_repository`:
+//! the `ToRedisArgs` / `FromRedisValue` round-trip and the error path a
+//! malformed/corrupt payload takes (must return a `RedisError`, not panic).
+
+use redis::{FromRedisValue, ToRedisArgs, Value};
+use rust_bot::chat_gpt_handler::BotProfile;
+use rust_bot::gpt_service::{ChatMessage, ChatMessageRole};
+
+#[test]
+fn chat_message_round_trips_through_redis_encoding() {
+    let original = ChatMessage {
+        role: ChatMessageRole::User,
+        content: "привет, как дела?".to_string(),
+    };
+
+    let args = original.to_redis_args();
+    assert_eq!(args.len(), 1, "ChatMessage should encode to a single arg");
+
+    let decoded = ChatMessage::from_redis_value(&Value::Data(args[0].clone()))
+        .expect("decode ChatMessage from its own encoding");
+
+    assert_eq!(decoded.content, original.content);
+    // `ChatMessageRole` has no `PartialEq`; compare via its serialized form.
+    assert_eq!(
+        serde_json::to_string(&decoded.role).unwrap(),
+        serde_json::to_string(&original.role).unwrap(),
+    );
+}
+
+#[test]
+fn bot_profile_round_trips_through_redis_encoding() {
+    for profile in [BotProfile::Fedor, BotProfile::Felix, BotProfile::Ferris] {
+        let args = profile.to_redis_args();
+        let decoded = BotProfile::from_redis_value(&Value::Data(args[0].clone()))
+            .expect("decode BotProfile from its own encoding");
+        assert_eq!(decoded, profile);
+    }
+}
+
+#[test]
+fn chat_message_from_malformed_value_is_error_not_panic() {
+    let result = ChatMessage::from_redis_value(&Value::Data(b"not valid json".to_vec()));
+    assert!(
+        result.is_err(),
+        "a corrupt ChatMessage payload must return an error"
+    );
+}
+
+#[test]
+fn bot_profile_from_unknown_variant_is_error_not_panic() {
+    let result = BotProfile::from_redis_value(&Value::Data(b"\"NotAProfile\"".to_vec()));
+    assert!(
+        result.is_err(),
+        "an unknown BotProfile must return an error"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -192,6 +192,50 @@ pub fn text_message_update(text: &str, chat_id: i64, user_id: i64, message_id: i
     serde_json::from_str(&serialized).expect("build Update")
 }
 
+/// Like [`text_message_update`], but the message is a reply to an earlier
+/// (bot) message with id `reply_to_message_id` — needed to route through the
+/// `handle_reply` branch of the dispatcher.
+pub fn reply_message_update(
+    text: &str,
+    chat_id: i64,
+    user_id: i64,
+    message_id: i32,
+    reply_to_message_id: i32,
+) -> Update {
+    let now = chrono::Utc::now().timestamp();
+    let chat = json!({ "id": chat_id, "type": "supergroup", "title": "test-chat" });
+    let value: Value = json!({
+        "update_id": message_id,
+        "message": {
+            "message_id": message_id,
+            "date": now,
+            "chat": chat.clone(),
+            "from": {
+                "id": user_id,
+                "is_bot": false,
+                "first_name": "Alice",
+                "username": "alice"
+            },
+            "text": text,
+            "entities": [],
+            "reply_to_message": {
+                "message_id": reply_to_message_id,
+                "date": now,
+                "chat": chat,
+                "from": {
+                    "id": 1,
+                    "is_bot": true,
+                    "first_name": "TestBot",
+                    "username": "test_bot"
+                },
+                "text": "previous bot message"
+            }
+        }
+    });
+    let serialized = serde_json::to_string(&value).expect("serialize update json");
+    serde_json::from_str(&serialized).expect("build reply Update")
+}
+
 /// Build deps, dispatch a single update through the real handler tree, and
 /// fail fast if anything stalls.
 pub async fn dispatch_one(bot: Bot, pool: PgPool, gpt_parameters: GptParameters, update: Update) {

--- a/tests/handler_routes_e2e.rs
+++ b/tests/handler_routes_e2e.rs
@@ -1,0 +1,117 @@
+//! End-to-end coverage for the handler routes the existing e2e suite did not
+//! reach: the blazing-fast mention, the gayness mention (restrict + reply), and
+//! the reply-to-a-bot-message path through `handle_reply`.
+
+mod common;
+
+use common::*;
+use rust_bot::chat_gpt_handler::BotProfile;
+use rust_bot::chat_repository;
+
+fn send_message_bodies(requests: &[wiremock::Request]) -> Vec<String> {
+    requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/SendMessage"))
+        .map(|r| String::from_utf8_lossy(&r.body).to_string())
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blazing_fast_mention_replies() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let (_openai, openai_url) = spawn_openai("unused").await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    // "blazing fast" matches BLAZING_FAST_REGEX and no earlier route.
+    let update = text_message_update("blazing fast is a myth", -1_005_000, 55, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+    let bodies = send_message_bodies(&requests);
+    assert_eq!(bodies.len(), 1, "expected one reply, got {}", bodies.len());
+    assert!(
+        bodies[0].contains("Did you mean Rust"),
+        "sendMessage body: {}",
+        bodies[0]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gayness_mention_restricts_and_replies() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let (_openai, openai_url) = spawn_openai("unused").await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    // "I am 3% gay" matches GAYNESS_REGEX (the " 3% g" substring).
+    let update = text_message_update("I am 3% gay", -1_006_000, 66, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+
+    let restrict_count = requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/RestrictChatMember"))
+        .count();
+    assert_eq!(restrict_count, 1, "expected one restrictChatMember call");
+
+    let bodies = send_message_bodies(&requests);
+    assert_eq!(bodies.len(), 1, "expected one reply, got {}", bodies.len());
+    assert!(
+        bodies[0].contains("mute"),
+        "sendMessage body: {}",
+        bodies[0]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reply_to_bot_message_routes_to_gpt() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let canned = "И тебе не хворать.";
+    let (openai, openai_url) = spawn_openai(canned).await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    let chat_id = -1_007_000_i64;
+    let bot_msg_id = 500_i32;
+
+    // Seed: the replied-to message was sent under the Fedor profile. Use the
+    // same key format the handler builds (`chat:{chat_id:#?}`).
+    let mut cm = redis.connection_manager.clone();
+    let chat_key = format!("chat:{chat_id:#?}");
+    chat_repository::push_bot_msg_identifier(&mut cm, &chat_key, bot_msg_id, BotProfile::Fedor)
+        .await
+        .expect("seed bot msg profile");
+
+    // Neutral text (no keyword) replying to that bot message -> handle_reply.
+    let update = reply_message_update("спасибо", chat_id, 77, 1, bot_msg_id);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let openai_calls = openai
+        .received_requests()
+        .await
+        .expect("collect openai requests");
+    assert_eq!(openai_calls.len(), 1, "reply should trigger one gpt call");
+
+    let requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+    let bodies = send_message_bodies(&requests);
+    assert_eq!(bodies.len(), 1, "expected one reply, got {}", bodies.len());
+    assert!(
+        bodies[0].contains(canned),
+        "sendMessage body: {}",
+        bodies[0]
+    );
+}

--- a/tests/mention_repository_test.rs
+++ b/tests/mention_repository_test.rs
@@ -1,0 +1,72 @@
+//! Direct coverage of `mention_repository` against a real Postgres
+//! (testcontainers), exercising the insert / lead-earliest-mention-time queries
+//! and the `ON CONFLICT` upsert that the rust-mention handler relies on.
+
+mod common;
+
+use common::spawn_postgres;
+use rust_bot::mention_repository;
+use sqlx::types::chrono::NaiveDateTime;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn insert_upserts_and_lead_time_reflects_state() {
+    let pg = spawn_postgres().await;
+    let chat_id = -4242_i64;
+    let user_id = 7_i64;
+
+    // No rows for this chat yet -> the query returns the MAX sentinel.
+    let empty = mention_repository::lead_earliest_mention_time(&pg.pool, chat_id)
+        .await
+        .expect("lead time on empty table");
+    assert_eq!(
+        empty,
+        NaiveDateTime::MAX,
+        "empty chat should yield the sentinel"
+    );
+
+    // First insert creates exactly one row with counter = 1 (column default).
+    mention_repository::insert_mention(&pg.pool, user_id, "alice", chat_id)
+        .await
+        .expect("first insert");
+
+    let (count, counter) = row_stats(&pg.pool, user_id, chat_id).await;
+    assert_eq!(count, 1, "one row after first insert");
+    assert_eq!(counter, 1, "counter starts at 1");
+
+    // lead time now returns a real timestamp, not the sentinel.
+    let after_insert = mention_repository::lead_earliest_mention_time(&pg.pool, chat_id)
+        .await
+        .expect("lead time after insert");
+    assert_ne!(
+        after_insert,
+        NaiveDateTime::MAX,
+        "should return a real timestamp"
+    );
+
+    // Re-inserting the same (user, chat) upserts: still one row, counter bumped.
+    mention_repository::insert_mention(&pg.pool, user_id, "alice", chat_id)
+        .await
+        .expect("second insert (conflict)");
+
+    let (count2, counter2) = row_stats(&pg.pool, user_id, chat_id).await;
+    assert_eq!(count2, 1, "ON CONFLICT should update, not add a row");
+    assert_eq!(counter2, 2, "counter should increment on conflict");
+}
+
+async fn row_stats(pool: &sqlx::PgPool, user_id: i64, chat_id: i64) -> (i64, i32) {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM mentions WHERE user_id = $1 AND chat_id = $2")
+            .bind(user_id)
+            .bind(chat_id)
+            .fetch_one(pool)
+            .await
+            .expect("count rows");
+    let counter: i32 =
+        sqlx::query_scalar("SELECT counter FROM mentions WHERE user_id = $1 AND chat_id = $2")
+            .bind(user_id)
+            .bind(chat_id)
+            .fetch_one(pool)
+            .await
+            .expect("read counter");
+    (count, counter)
+}

--- a/tests/url_summary_e2e.rs
+++ b/tests/url_summary_e2e.rs
@@ -61,3 +61,32 @@ async fn url_summary_fetches_article_summarizes_and_replies() {
     assert!(body.contains("TLDR"), "sendMessage body: {body}");
     assert!(body.contains(canned_summary), "sendMessage body: {body}");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn url_summary_unreachable_source_does_not_reply() {
+    let pg = spawn_postgres().await;
+    let redis = spawn_redis().await;
+    let (telegram, bot) = spawn_telegram().await;
+    let (_openai, openai_url) = spawn_openai("unused").await;
+    let gpt = gpt_parameters(redis.connection_manager.clone(), openai_url);
+
+    // Port 1 refuses connections immediately, so `get_content_call` errors,
+    // `handle_url_summary` returns `Err`, and the dispatcher logs + swallows it.
+    // The dispatcher still routes (dispatch_one asserts no panic) and no reply
+    // goes out.
+    let update = text_message_update("посмотри http://127.0.0.1:1/article", -1004000, 88, 1);
+    dispatch_one(bot, pg.pool.clone(), gpt, update).await;
+
+    let telegram_requests = telegram
+        .received_requests()
+        .await
+        .expect("collect telegram requests");
+    let send_count = telegram_requests
+        .iter()
+        .filter(|r| r.url.path().ends_with("/SendMessage"))
+        .count();
+    assert_eq!(
+        send_count, 0,
+        "no reply should be sent when the article source is unreachable"
+    );
+}


### PR DESCRIPTION
**Iteration 7/8** of the hardening plan (§2 — close the remaining test gaps).

New coverage (all additive — no production code touched):

- **`tests/chat_repository_test.rs`** (pure, no container) — `ToRedisArgs`/`FromRedisValue` round-trip for `ChatMessage`/`BotProfile`, plus the **malformed-payload → error (not panic)** path added in Iteration 4.
- **`tests/mention_repository_test.rs`** (testcontainers Postgres) — direct `insert_mention` / `lead_earliest_mention_time`, including the `ON CONFLICT` upsert and `counter` increment.
- **`tests/handler_routes_e2e.rs`** — e2e for the previously-uncovered `handle_bf_matched_mention`, `handle_gayness_mention` (restrict + reply), and `handle_reply` (reply-to-a-bot-message, via a new `reply_message_update` harness helper).
- **`tests/url_summary_e2e.rs`** — a **failing-source** case (unreachable article URL) that exercises the `AppError::Http` path and asserts the dispatcher swallows it with **no reply and no panic** — the error branch e2e previously never reached (flagged during Iteration 4 review).

Local gate green: fmt, clippy `--all-targets -D warnings`, 11 unit + 4 pure serde tests. The container-backed tests run in the `e2e` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)