### PR TITLE
ci: auto-merge Dependabot PRs that pass all required checks

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,9 @@
 name: Dependabot auto-merge
 
-# Enables GitHub's native auto-merge on Dependabot PRs. The PR is only merged
-# once every *required* status check on `main` passes (lint, build, e2e,
-# audit) — auto-merge does the waiting; this workflow just turns it on.
+# Enables GitHub's native auto-merge on Dependabot PRs for patch/minor bumps.
+# The PR is only merged once every *required* status check on `main` passes
+# (lint, build, e2e, audit) — auto-merge does the waiting; this workflow just
+# turns it on. Major version bumps are left open for manual review.
 on:
   pull_request:
     branches:
@@ -18,11 +19,17 @@ jobs:
     # Only act on Dependabot's own PRs.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - name: Enable auto-merge (squash)
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge (squash) for non-major bumps
+        # Skip major version bumps — they can pass CI yet carry behavioral or
+        # API risk, so a human reviews and merges them. For grouped updates
+        # `update-type` reflects the highest bump in the group.
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # To later restrict auto-merge to non-major bumps, add a
-      # `dependabot/fetch-metadata@v2` step and guard the merge with:
-      #   if: steps.metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# Enables GitHub's native auto-merge on Dependabot PRs. The PR is only merged
+# once every *required* status check on `main` passes (lint, build, e2e,
+# audit) — auto-merge does the waiting; this workflow just turns it on.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on Dependabot's own PRs.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # To later restrict auto-merge to non-major bumps, add a
+      # `dependabot/fetch-metadata@v2` step and guard the merge with:
+      #   if: steps.metadata.outputs.update-type != 'version-update:semver-major'


### PR DESCRIPTION
Enables GitHub's native **auto-merge (squash)** on Dependabot's own PRs for **patch and minor** bumps. A new workflow (`dependabot-automerge.yml`) turns on auto-merge; GitHub then merges only once the branch's **required status checks pass** — so a bump lands only when the full suite is green. **Major bumps are left open for manual review** (gated via `dependabot/fetch-metadata` on `update-type != semver-major`).

**Companion change (already applied to `main` branch protection):** required status checks expanded from just `build` to **`lint` + `build` + `e2e` + `audit`**. Without this, auto-merge would fire on `build` alone. CodeQL is intentionally left non-required (it legitimately "skips" on some docker/actions-only PRs, which would otherwise stall merges). `allow_update_branch` is on, so auto-merge auto-updates a behind PR branch under the `strict` (up-to-date) rule.

No approval step — `main` requires 0 reviews.

**Consequences:**
- These required checks now gate **all** PRs (human + Dependabot), not just this workflow.
- Auto-merge → push to `main` → `deploy.yml` → `flyctl deploy`, so passing non-major bumps **ship to production automatically**.

Note: this PR is not itself a Dependabot PR, so it won't auto-merge — merged manually once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)