### PR TITLE
ci: auto-approve Dependabot non-major bumps before auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,9 +1,10 @@
 name: Dependabot auto-merge
 
-# Enables GitHub's native auto-merge on Dependabot PRs for patch/minor bumps.
-# The PR is only merged once every *required* status check on `main` passes
-# (lint, build, e2e, audit) — auto-merge does the waiting; this workflow just
-# turns it on. Major version bumps are left open for manual review.
+# Approves and enables GitHub's native auto-merge on Dependabot PRs for
+# patch/minor bumps. The approval satisfies the branch's "require 1 review"
+# rule (human PRs still need a human reviewer); the merge then waits for every
+# required status check (lint, build, e2e, audit) to pass. Major version bumps
+# are left open for manual review — neither approved nor auto-merged.
 on:
   pull_request:
     branches:
@@ -24,6 +25,15 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve non-major bumps
+        # The bot's approval satisfies the required review for Dependabot's own
+        # PRs; human PRs get no such approval and still need a human reviewer.
+        # Skipped for majors so those keep needing a genuine human approval.
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge (squash) for non-major bumps
         # Skip major version bumps — they can pass CI yet carry behavioral or
         # API risk, so a human reviews and merges them. For grouped updates


### PR DESCRIPTION
Implements **"human PRs gated by review, Dependabot flows through automatically."**

**Workflow change:** the Dependabot auto-merge job now runs `gh pr review --approve` before enabling auto-merge, for **non-major** bumps only. The bot's approval satisfies the require-1-review rule for Dependabot's *own* PRs; human PRs get no such approval and still need a human reviewer. Major bumps are neither approved nor auto-merged (a human reviews + merges them).

**Companion branch-protection changes (applied after this merges):**
- Required approvals: **0 → 1** (gates all PRs, incl. human).
- **Remove the single-user push restriction** on `main` — otherwise the Actions token still can't merge even after approving (this was the `enablePullRequestAutoMerge` "not authorized" error). `main` remains protected by the required review + the 4 required checks.

Already in place: "Allow GitHub Actions to approve PRs" (`can_approve_pull_request_reviews: true`); `dismiss_stale_reviews: false` (so the bot's approval survives Dependabot rebases).

Note: `enforce_admins` stays off, so admins still bypass — human-PR review is enforced for non-admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)