### PR TITLE
ci: gate Dependabot auto-merge on github.actor, not PR author

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,8 +17,12 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only act on Dependabot's own PRs.
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    # Only act on events Dependabot itself triggered (opened the PR or rebased
+    # it). Gating on `github.actor` — not the PR author — matches what
+    # dependabot/fetch-metadata requires: when a human triggers the event (e.g.
+    # clicks "Update branch"), github.actor is that human and fetch-metadata
+    # aborts with "PR is not from Dependabot". Skipping the job avoids that.
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
Fixes the **"PR is not from Dependabot, nothing to do"** error seen on #611.

**Cause:** the job was gated on `github.event.pull_request.user.login == 'dependabot[bot]'` (the PR *author*), so it ran even when a **human** triggered the event — e.g. clicking "Update branch" (run showed `triggering_actor: nolik`). `dependabot/fetch-metadata` then checks `github.actor` (the human), can't confirm Dependabot, and exits 1.

**Fix:** gate the job on `github.actor == 'dependabot[bot]'` — the event's triggering actor, which is what `fetch-metadata` requires and GitHub's docs recommend. Now:
- Dependabot opens or **rebases** a PR → `github.actor` is Dependabot → job runs (approve + auto-merge).
- A human interacts with a Dependabot PR → job **skips** cleanly (no error). Auto-merge/approval already persist, so nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)